### PR TITLE
Fix spring-security-oauth gh-1024

### DIFF
--- a/src/main/java/com/common/config/ResourceServerConfig.java
+++ b/src/main/java/com/common/config/ResourceServerConfig.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 
 @Configuration
 @EnableResourceServer
-@Order(99)
 public class ResourceServerConfig extends ResourceServerConfigurerAdapter {
 
 	public static final String RESOURCE_ID = "myapp/api";
@@ -37,12 +36,8 @@ public class ResourceServerConfig extends ResourceServerConfigurerAdapter {
 
 	@Override
 	public void configure(HttpSecurity http) throws Exception {
-		http.antMatcher("/**") // ### Specify path pattern that need OAuth authentication(Bearer auth) and authorization
-				.requestMatchers().antMatchers(
-						"/**"
-					).and()
+		http
 				.authorizeRequests()
-					.antMatchers(HttpMethod.GET, HttpPathStore.PING).permitAll()
 				.anyRequest()
 					.access("#oauth2.hasScope('write') " +
 							"and #oauth2.clientHasRole('ROLE_CLIENT') " +

--- a/src/main/java/com/common/config/SecurityConfig.java
+++ b/src/main/java/com/common/config/SecurityConfig.java
@@ -35,6 +35,8 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.session.web.http.CookieSerializer;
 import org.springframework.session.web.http.DefaultCookieSerializer;
 
@@ -76,6 +78,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		http
+			.requestMatcher(new OrRequestMatcher(new AntPathRequestMatcher(HttpPathStore.LOGIN), new AntPathRequestMatcher(HttpPathStore.LOGOUT), new AntPathRequestMatcher(HttpPathStore.PING)))
 			.sessionManagement()
 				.sessionCreationPolicy(SessionCreationPolicy.NEVER)
 				.and()

--- a/src/main/java/com/common/config/SecurityConfig.java
+++ b/src/main/java/com/common/config/SecurityConfig.java
@@ -78,7 +78,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		http
-			.requestMatcher(new OrRequestMatcher(new AntPathRequestMatcher(HttpPathStore.LOGIN), new AntPathRequestMatcher(HttpPathStore.LOGOUT), new AntPathRequestMatcher(HttpPathStore.PING)))
+			.requestMatcher(new OrRequestMatcher(new AntPathRequestMatcher(HttpPathStore.LOGIN), new AntPathRequestMatcher(HttpPathStore.LOGOUT), new AntPathRequestMatcher(HttpPathStore.PING), new AntPathRequestMatcher("/oauth/authorize")))
 			.sessionManagement()
 				.sessionCreationPolicy(SessionCreationPolicy.NEVER)
 				.and()


### PR DESCRIPTION
I've fixed your issue.

What do you think ?

### Ping
```
$ curl -v --silent http://localhost:8081/ping
*   Trying ::1...
* Connected to localhost (::1) port 8081 (#0)
> GET /ping HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.43.0
> Accept: */*
> 
< HTTP/1.1 200 
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE, PUT, PATCH
< Access-Control-Max-Age: 3600
< Access-Control-Allow-Headers: Content-Type, Accept, Authorization, X-Requested-With, remember-me
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Cache-Control: no-cache, no-store, max-age=0, must-revalidate
< Pragma: no-cache
< Expires: 0
< X-Frame-Options: DENY
< Content-Type: application/json;charset=UTF-8
< Transfer-Encoding: chunked
< Date: Mon, 20 Mar 2017 12:07:06 GMT
< 
* Connection #0 to host localhost left intact
{"date":1490011626752,"message":"Welcome to our API","status":"OK"}
```

### Form Login

```
$ curl -d username=admin -d password=verysecret -v --silent http://localhost:8081/login
*   Trying ::1...
* Connected to localhost (::1) port 8081 (#0)
> POST /login HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.43.0
> Accept: */*
> Content-Length: 34
> Content-Type: application/x-www-form-urlencoded
> 
* upload completely sent off: 34 out of 34 bytes
< HTTP/1.1 200 
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE, PUT, PATCH
< Access-Control-Max-Age: 3600
< Access-Control-Allow-Headers: Content-Type, Accept, Authorization, X-Requested-With, remember-me
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Cache-Control: no-cache, no-store, max-age=0, must-revalidate
< Pragma: no-cache
< Expires: 0
< X-Frame-Options: DENY
< Content-Length: 68
< Date: Mon, 20 Mar 2017 12:07:56 GMT
< 
* Connection #0 to host localhost left intact
{"defaultMessage":"You are connected","id":"api.auth.login.success"}
```

### Logout

```
$ curl -X POST -v --silent http://localhost:8081/logout
*   Trying ::1...
* Connected to localhost (::1) port 8081 (#0)
> POST /logout HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.43.0
> Accept: */*
> 
< HTTP/1.1 200 
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE, PUT, PATCH
< Access-Control-Max-Age: 3600
< Access-Control-Allow-Headers: Content-Type, Accept, Authorization, X-Requested-With, remember-me
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Cache-Control: no-cache, no-store, max-age=0, must-revalidate
< Pragma: no-cache
< Expires: 0
< X-Frame-Options: DENY
< Content-Length: 72
< Date: Mon, 20 Mar 2017 12:17:58 GMT
< 
* Connection #0 to host localhost left intact
{"defaultMessage":"You are disconnected","id":"api.auth.logout.success"}
```

### Resource access without access token

```
$ curl -v http://localhost:8081/
*   Trying ::1...
* Connected to localhost (::1) port 8081 (#0)
> GET / HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.43.0
> Accept: */*
> 
< HTTP/1.1 401 
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE, PUT, PATCH
< Access-Control-Max-Age: 3600
< Access-Control-Allow-Headers: Content-Type, Accept, Authorization, X-Requested-With, remember-me
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Cache-Control: no-cache, no-store, max-age=0, must-revalidate
< Pragma: no-cache
< Expires: 0
< X-Frame-Options: DENY
< Cache-Control: no-store
< Pragma: no-cache
< WWW-Authenticate: Bearer realm="myapp/api", error="unauthorized", error_description="Full authentication is required to access this resource"
< Content-Type: application/json;charset=UTF-8
< Transfer-Encoding: chunked
< Date: Mon, 20 Mar 2017 12:09:59 GMT
< 
* Connection #0 to host localhost left intact
{"error":"unauthorized","error_description":"Full authentication is required to access this resource"}
```

###  Resource access with invalid access token

```
$ curl -v -H "Authorization: Bearer xxxxx" http://localhost:8081/
*   Trying ::1...
* Connected to localhost (::1) port 8081 (#0)
> GET / HTTP/1.1
> Host: localhost:8081
> User-Agent: curl/7.43.0
> Accept: */*
> Authorization: Bearer xxxxx
> 
< HTTP/1.1 401 
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE, PUT, PATCH
< Access-Control-Max-Age: 3600
< Access-Control-Allow-Headers: Content-Type, Accept, Authorization, X-Requested-With, remember-me
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Cache-Control: no-cache, no-store, max-age=0, must-revalidate
< Pragma: no-cache
< Expires: 0
< X-Frame-Options: DENY
< Cache-Control: no-store
< Pragma: no-cache
< WWW-Authenticate: Bearer realm="myapp/api", error="invalid_token", error_description="Invalid access token: xxxxx"
< Content-Type: application/json;charset=UTF-8
< Transfer-Encoding: chunked
< Date: Mon, 20 Mar 2017 12:10:43 GMT
< 
* Connection #0 to host localhost left intact
{"error":"invalid_token","error_description":"Invalid access token: xxxxx"}
```

### Resource access with valid access token

Please try using a valid client on your application.

Thanks.
